### PR TITLE
Print error reports even if tests are rerun

### DIFF
--- a/pytest_progress.py
+++ b/pytest_progress.py
@@ -139,7 +139,7 @@ class ProgressTerminalReporter(TerminalReporter):
         # Show failures and errors occuring during running a test
         # instantly.
         TerminalReporter.pytest_runtest_logreport(self, report)
-        if report.failed and not hasattr(report, 'wasxfail'):
+        if (report.failed or report.outcome == "rerun") and not hasattr(report, 'wasxfail'):
             if self.verbosity <= 0:
                 self._tw.line()
             self.print_failure(report)


### PR DESCRIPTION
As a test developer I want to know why my tests are flaky.